### PR TITLE
feat: downgrade playready pssh

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,7 +175,8 @@ declare namespace dashjs {
             },
             protection?: {
                 keepProtectionMediaKeys?: boolean,
-                ignoreEmeEncryptedEvent?: boolean
+                ignoreEmeEncryptedEvent?: boolean,
+                downgradePlayReadyPSSH?: boolean
             },
             buffer?: {
                 enableSeekDecorrelationFix?: boolean,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.0-doris.1",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.0-doris.1",
+    "version": "4.3.0",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -525,6 +525,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * If true, the ProtectionController and then created MediaKeys and MediaKeySessions will be preserved during the MediaPlayer lifetime.
  * @property {boolean} ignoreEmeEncryptedEvent
  * If set to true the player will ignore "encrypted" and "needkey" events thrown by the EME.
+ * @property {boolean} downgradePlayReadyPSSH
+ * If set to true the player will downgrade v1 PSSH boxes to v0.
  */
 
 /**
@@ -778,7 +780,8 @@ function Settings() {
             },
             protection: {
                 keepProtectionMediaKeys: false,
-                ignoreEmeEncryptedEvent: false
+                ignoreEmeEncryptedEvent: false,
+                downgradePlayReadyPSSH: false
             },
             buffer: {
                 enableSeekDecorrelationFix: false,

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -40,6 +40,7 @@ import {HTTPRequest} from '../../vo/metrics/HTTPRequest';
 import Utils from '../../../core/Utils';
 import Constants from '../../constants/Constants';
 import FactoryMaker from '../../../core/FactoryMaker';
+import ProtectionConstants from '../../constants/ProtectionConstants';
 
 const NEEDKEY_BEFORE_INITIALIZE_RETRIES = 5;
 const NEEDKEY_BEFORE_INITIALIZE_TIMEOUT = 500;
@@ -308,7 +309,19 @@ function ProtectionController(config) {
      * @ignore
      */
     function createKeySession(keySystemInfo) {
-        const initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo ? keySystemInfo.initData : null);
+        let initDataForKS = CommonEncryption.getPSSHForKeySystem(selectedKeySystem, keySystemInfo ? keySystemInfo.initData : null);
+
+        if(
+            settings.get().streaming.protection.downgradePlayReadyPSSH &&
+            keySystemInfo && keySystemInfo.ks.systemString === ProtectionConstants.PLAYREADY_KEYSTEM_STRING
+        ) {
+            if (initDataForKS) {
+                initDataForKS = _downgradePlayReadyPSSH(initDataForKS);
+            }
+            if (keySystemInfo && keySystemInfo.initData) {
+                keySystemInfo.initData = _downgradePlayReadyPSSH(keySystemInfo.initData);
+            }
+        }
 
         if (initDataForKS) {
 
@@ -340,6 +353,48 @@ function ProtectionController(config) {
             });
         }
     }
+
+    /**
+     * Rewrites v1 PlayReady PSSH boxes to v0.
+     *
+     * @param {ArrayBuffer} initData
+     * @returns {ArrayBuffer}
+     */
+     function _downgradePlayReadyPSSH(initData) {
+        try {
+            const dataView = new DataView(initData);
+
+            // Check if file header is 'pssh'
+            if (dataView.getUint32(4) !== 0x70737368) {
+                throw new Error('initData is not PlayReady PSSH');
+            }
+
+            const version = dataView.getUint8(8);
+            if (version > 0) {
+                const keyIdCount = dataView.getUint32(28);
+                const bytesToRemove = 4 + keyIdCount * 16;
+                const newSize = initDataArray.byteLength - bytesToRemove;
+
+                // Set new size without key IDs
+                dataView.setUint32(0, newSize);
+                // Change version to 0
+                dataView.setUint8(8, 0);
+
+                // Create new PSSH
+                const initDataArray = new Uint8Array(initData);
+                const pssh = new Uint8Array(newSize);
+                pssh.set(initDataArray.subarray(0, 28));
+                pssh.set(initDataArray.subarray(28 + bytesToRemove), 28);
+
+                logger.info('PlayReady PSSH downgraded to version 0');
+                return pssh.buffer;
+            }
+        } catch (e) {
+            logger.warn('Failed to downgrade PlayReady PSSH! ' + e.message);
+        }
+        return initData;
+    };
+
 
     /**
      * Returns the protectionData for a specific keysystem as specified by the application.

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -373,7 +373,7 @@ function ProtectionController(config) {
             if (version > 0) {
                 const keyIdCount = dataView.getUint32(28);
                 const bytesToRemove = 4 + keyIdCount * 16;
-                const newSize = initDataArray.byteLength - bytesToRemove;
+                const newSize = initData.byteLength - bytesToRemove;
 
                 // Set new size without key IDs
                 dataView.setUint32(0, newSize);


### PR DESCRIPTION
## Description

Adds a new `downgradePlayReadyPSSH` option to `settings.protection` to downgrade v1 PSSH boxes to v0. (Required on PlayStation 4)

## JIRA
[DORIS-1257](https://dicetech.atlassian.net/browse/DORIS-1257)