### PR TITLE
feat: supported codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,4 +188,4 @@ build/typings/
 # Vim
 .vimrc
 
-dashjs-*-doris.*.tgz
+dashjs-*.tgz

--- a/index.d.ts
+++ b/index.d.ts
@@ -158,7 +158,8 @@ declare namespace dashjs {
             eventControllerRefreshDelay?: number,
             capabilities?: {
                 filterUnsupportedEssentialProperties?: boolean,
-                useMediaCapabilitiesApi?: boolean
+                useMediaCapabilitiesApi?: boolean,
+                supportedCodecs?: string[]
             },
             timeShiftBuffer?: {
                 calcFromSegmentTimeline?: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -66,7 +66,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *            eventControllerRefreshDelay: 100,
  *            capabilities: {
  *               filterUnsupportedEssentialProperties: true,
- *               useMediaCapabilitiesApi: false
+ *               useMediaCapabilitiesApi: false,
+ *               supportedCodecs: []
  *            },
  *            timeShiftBuffer: {
  *                calcFromSegmentTimeline: false,
@@ -535,6 +536,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Enable to filter all the AdaptationSets and Representations which contain an unsupported \<EssentialProperty\> element.
  * @property {boolean} [useMediaCapabilitiesApi=false]
  * Enable to use the MediaCapabilities API to check whether codecs are supported. If disabled MSE.isTypeSupported will be used instead.
+ * @property {Array.<string>} [supportedCodecs=[]]
+ * List of supported codecs that will not be filtered out.
  */
 
 /**
@@ -763,7 +766,8 @@ function Settings() {
             eventControllerRefreshDelay: 150,
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
-                useMediaCapabilitiesApi: false
+                useMediaCapabilitiesApi: false,
+                supportedCodecs: []
             },
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -948,7 +948,7 @@ function Settings() {
         for (let n in source) {
             if (source.hasOwnProperty(n)) {
                 if (dest.hasOwnProperty(n)) {
-                    if (typeof source[n] === 'object' && source[n] !== null) {
+                    if (typeof source[n] === 'object' && source[n] !== null && !Array.isArray(source[n])) {
                         mixinSettings(source[n], dest[n], path.slice() + n + '.');
                     } else {
                         dest[n] = Utils.clone(source[n]);

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -117,7 +117,12 @@ function Capabilities() {
      * @returns {boolean}
      */
     function _isSupportedCodec(config) {
-        return settings.get().streaming.capabilities.supportedCodecs.indexOf(config.codec) !== -1;
+        function formatCodec(codec) {
+            return codec.split(' ').join('').toLowerCase();
+        }
+        return settings.get().streaming.capabilities.supportedCodecs.some((codec) => {
+            return formatCodec(codec) === formatCodec(config.codec);
+        });
     }
 
     /**

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -117,6 +117,8 @@ function Capabilities() {
      * @returns {boolean}
      */
     function _isSupportedCodec(config) {
+        // Example:
+        // 'video/mp4; codecs="avc1.640029"'
         function formatCodec(codec) {
             return codec.split(' ').join('').toLowerCase();
         }

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -100,11 +100,24 @@ function Capabilities() {
             return Promise.resolve(true);
         }
 
+        if (_isSupportedCodec(config)) {
+            return Promise.resolve(true);
+        }
+
         if (_canUseMediaCapabilitiesApi(config, type)) {
             return _checkCodecWithMediaCapabilities(config, type);
         }
 
         return _checkCodecWithMse(config);
+    }
+
+    /**
+     * Indicates, whether the given codec is whitelisted as a supported codec in the config.
+     * @param {object} config
+     * @returns {boolean}
+     */
+    function _isSupportedCodec(config) {
+        return settings.get().streaming.capabilities.supportedCodecs.indexOf(config.codec) !== -1;
     }
 
     /**

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -133,7 +133,7 @@ function CapabilitiesFilter() {
                         }
                         return supported[i];
                     });
-                    resolve();
+                    resolve()
                 })
                 .catch(() => {
                     resolve();


### PR DESCRIPTION
## Description

Added `supportedCodecs` to capabilities. Codec strings listed here will not be checked with `MediaSource.isTypeSupported`. 

```
streaming: {
  capabilities: {
    supportedCodecs: ['video/mp4;codecs="avc1.640029"']
  }
}
```