### PR TITLE
feat: replace codecs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,7 @@ declare namespace dashjs {
             capabilities?: {
                 filterUnsupportedEssentialProperties?: boolean,
                 useMediaCapabilitiesApi?: boolean,
-                supportedCodecs?: string[]
+                replaceCodecs?: [from: string, to: string][]
             },
             timeShiftBuffer?: {
                 calcFromSegmentTimeline?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,7 @@ declare namespace dashjs {
             capabilities?: {
                 filterUnsupportedEssentialProperties?: boolean,
                 useMediaCapabilitiesApi?: boolean,
-                replaceCodecs?: [from: string, to: string][]
+                replaceCodecs?: [string, string][]
             },
             timeShiftBuffer?: {
                 calcFromSegmentTimeline?: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -67,7 +67,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *            capabilities: {
  *               filterUnsupportedEssentialProperties: true,
  *               useMediaCapabilitiesApi: false,
- *               supportedCodecs: []
+ *               replaceCodecs: []
  *            },
  *            timeShiftBuffer: {
  *                calcFromSegmentTimeline: false,
@@ -536,8 +536,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Enable to filter all the AdaptationSets and Representations which contain an unsupported \<EssentialProperty\> element.
  * @property {boolean} [useMediaCapabilitiesApi=false]
  * Enable to use the MediaCapabilities API to check whether codecs are supported. If disabled MSE.isTypeSupported will be used instead.
- * @property {Array.<string>} [supportedCodecs=[]]
- * List of supported codecs that will not be filtered out.
+ * @property {Array.<[string, string]>} [replaceCodecs=[]]
+ * List of codecs to be replaced.
  */
 
 /**
@@ -767,7 +767,7 @@ function Settings() {
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
                 useMediaCapabilitiesApi: false,
-                supportedCodecs: []
+                replaceCodecs: []
             },
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -248,6 +248,13 @@ function MssParser(config) {
             representation.codecs = constants.STPP;
         }
 
+        const { replaceCodecs } = settings.get().streaming.capabilities;
+        for (const [from, to] of replaceCodecs) {
+            if (representation.codecs === from) {
+                representation.codecs = to;
+            }
+          }
+
         representation.codecPrivateData = '' + qualityLevel.getAttribute('CodecPrivateData');
         representation.BaseURL = qualityLevel.BaseURL;
 

--- a/src/mss/parser/MssParser.js
+++ b/src/mss/parser/MssParser.js
@@ -248,13 +248,6 @@ function MssParser(config) {
             representation.codecs = constants.STPP;
         }
 
-        const { replaceCodecs } = settings.get().streaming.capabilities;
-        for (const [from, to] of replaceCodecs) {
-            if (representation.codecs === from) {
-                representation.codecs = to;
-            }
-          }
-
         representation.codecPrivateData = '' + qualityLevel.getAttribute('CodecPrivateData');
         representation.BaseURL = qualityLevel.BaseURL;
 

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -95,12 +95,7 @@ function Capabilities() {
      * @return {Promise<boolean>}
      */
     function supportsCodec(config, type) {
-
         if (type !== Constants.AUDIO && type !== Constants.VIDEO) {
-            return Promise.resolve(true);
-        }
-
-        if (_isSupportedCodec(config)) {
             return Promise.resolve(true);
         }
 
@@ -109,22 +104,6 @@ function Capabilities() {
         }
 
         return _checkCodecWithMse(config);
-    }
-
-    /**
-     * Indicates, whether the given codec is whitelisted as a supported codec in the config.
-     * @param {object} config
-     * @returns {boolean}
-     */
-    function _isSupportedCodec(config) {
-        // Example:
-        // 'video/mp4; codecs="avc1.640029"'
-        function formatCodec(codec) {
-            return codec.split(' ').join('').toLowerCase();
-        }
-        return settings.get().streaming.capabilities.supportedCodecs.some((codec) => {
-            return formatCodec(codec) === formatCodec(config.codec);
-        });
     }
 
     /**

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -127,12 +127,22 @@ function CapabilitiesFilter() {
 
             Promise.all(promises)
                 .then((supported) => {
-                    as.Representation_asArray = as.Representation_asArray.filter((_, i) => {
-                        if (!supported[i]) {
-                            logger.debug(`[Stream] Codec ${configurations[i].codec} not supported `);
-                        }
-                        return supported[i];
-                    });
+                    as.Representation_asArray = as.Representation_asArray
+                        .map((representation) => {
+                            const { replaceCodecs } = settings.get().streaming.capabilities;
+                            for (const [from, to] of replaceCodecs) {
+                                if (representation.codecs === from) {
+                                    representation.codecs = to;
+                                }
+                            }
+                            return representation;
+                        })
+                        .filter((_, i) => {
+                            if (!supported[i]) {
+                                logger.debug(`[Stream] Codec ${configurations[i].codec} not supported `);
+                            }
+                            return supported[i];
+                        });
                     resolve()
                 })
                 .catch(() => {


### PR DESCRIPTION
Adds `replaceCodecs` to level controller config.
Allows codecs to be replaced by less specific versions. Useful on PlayStation 4 where AVC High Profile can be played back, but MSE is rejecting it's codec string.

_Removed `supportedCodecs` which did not satisfy the intended requirements._

Example:
```
capabilities: {
    replaceCodecs: [
        ['avc1.640029', 'avc1']
    ]
},
```