### PR TITLE
fix: replace strings before support check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.3",
+    "version": "4.3.4",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -117,7 +117,15 @@ function CapabilitiesFilter() {
             const promises = [];
             const configurations = [];
 
+            const { replaceCodecs } = settings.get().streaming.capabilities;
+
             as.Representation_asArray.forEach((rep, i) => {
+                for (const [from, to] of replaceCodecs) {
+                    if (rep.codecs?.toLowerCase() === from.toLowerCase()) {
+                        rep.codecs = to;
+                    }
+                }
+
                 const codec = adapter.getCodec(as, i, false);
                 const config = _createConfiguration(type,rep, codec);
 
@@ -128,15 +136,6 @@ function CapabilitiesFilter() {
             Promise.all(promises)
                 .then((supported) => {
                     as.Representation_asArray = as.Representation_asArray
-                        .map((representation) => {
-                            const { replaceCodecs } = settings.get().streaming.capabilities;
-                            for (const [from, to] of replaceCodecs) {
-                                if (representation.codecs === from) {
-                                    representation.codecs = to;
-                                }
-                            }
-                            return representation;
-                        })
                         .filter((_, i) => {
                             if (!supported[i]) {
                                 logger.debug(`[Stream] Codec ${configurations[i].codec} not supported `);


### PR DESCRIPTION
## Description

Use `toLowerCase()` when comparing codecs.
Moved codec replacement before support check.