### PR TITLE
fix: seeking live streams when missing mediaSource.setLiveSeekableRange

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -193,7 +193,8 @@ declare namespace dashjs {
                 longFormContentDurationThreshold?: number,
                 stallThreshold?: number,
                 useAppendWindow?: boolean,
-                setStallState?: boolean
+                setStallState?: boolean,
+                enableSetLiveSeekableRangeFix?: boolean
             },
             gaps?: {
                 jumpGaps?: boolean,

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,7 @@ declare namespace dashjs {
                 stallThreshold?: number,
                 useAppendWindow?: boolean,
                 setStallState?: boolean,
-                enableSetLiveSeekableRangeFix?: boolean
+                enableLiveSeekableRangeFix?: boolean
             },
             gaps?: {
                 jumpGaps?: boolean,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -100,7 +100,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *                stallThreshold: 0.5,
  *                useAppendWindow: true,
  *                setStallState: false,
- *                enableSetLiveSeekableRangeFix: false
+ *                enableSetLiveSeekableRangeFix: true
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -302,7 +302,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=false]
  * Specifies if we fire manual waiting events once the stall threshold is reached
- * @property {boolean} [enableSetLiveSeekableRangeFix=false]
+ * @property {boolean} [enableSetLiveSeekableRangeFix=true]
  * Sets `mediaSource.duration` when live seekable range changes if `mediaSource.setLiveSeekableRange` is unavailable.
  */
 
@@ -805,7 +805,7 @@ function Settings() {
                 stallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
-                enableSetLiveSeekableRangeFix: false
+                enableSetLiveSeekableRangeFix: true
             },
             gaps: {
                 jumpGaps: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -100,7 +100,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *                stallThreshold: 0.5,
  *                useAppendWindow: true,
  *                setStallState: false,
- *                enableSetLiveSeekableRangeFix: true
+ *                enableLiveSeekableRangeFix: true
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -302,7 +302,7 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=false]
  * Specifies if we fire manual waiting events once the stall threshold is reached
- * @property {boolean} [enableSetLiveSeekableRangeFix=true]
+ * @property {boolean} [enableLiveSeekableRangeFix=true]
  * Sets `mediaSource.duration` when live seekable range changes if `mediaSource.setLiveSeekableRange` is unavailable.
  */
 
@@ -805,7 +805,7 @@ function Settings() {
                 stallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
-                enableSetLiveSeekableRangeFix: true
+                enableLiveSeekableRangeFix: true
             },
             gaps: {
                 jumpGaps: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -99,7 +99,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  *                longFormContentDurationThreshold: 600,
  *                stallThreshold: 0.5,
  *                useAppendWindow: true,
- *                setStallState: false
+ *                setStallState: false,
+ *                enableSetLiveSeekableRangeFix: false
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -301,6 +302,8 @@ import {HTTPRequest} from '../streaming/vo/metrics/HTTPRequest';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=false]
  * Specifies if we fire manual waiting events once the stall threshold is reached
+ * @property {boolean} [enableSetLiveSeekableRangeFix=false]
+ * Sets `mediaSource.duration` when live seekable range changes if `mediaSource.setLiveSeekableRange` is unavailable.
  */
 
 /**
@@ -801,7 +804,8 @@ function Settings() {
                 longFormContentDurationThreshold: 600,
                 stallThreshold: 0.3,
                 useAppendWindow: true,
-                setStallState: true
+                setStallState: true,
+                enableSetLiveSeekableRangeFix: false
             },
             gaps: {
                 jumpGaps: true,

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -85,8 +85,8 @@ function MediaSourceController() {
         }
     }
 
-    function setSeekable(start, end, enableSetLiveSeekableRangeFix = false) {
-        if (Math.random() > 2 && mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
+    function setSeekable(start, end, enableSetLiveSeekableRangeFix) {
+        if (mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
             mediaSource.readyState === 'open' && start >= 0 && start < end) {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -86,8 +86,10 @@ function MediaSourceController() {
     }
 
     function setSeekable(start, end, enableSetLiveSeekableRangeFix) {
-        if (mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
-            mediaSource.readyState === 'open' && start >= 0 && start < end) {
+        if (!mediaSource || mediaSource.readyState !== 'open') return;
+        if (start < 0 || end <= start) return;
+
+        if (typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function') {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);
         } else if (enableSetLiveSeekableRangeFix) {

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -70,13 +70,15 @@ function MediaSourceController() {
         videoModel.setSource(null);
     }
 
-    function setDuration(value) {
+    function setDuration(value, log = true) {
         if (!mediaSource || mediaSource.readyState !== 'open') return;
         if (value === null && isNaN(value)) return;
         if (mediaSource.duration === value) return;
 
         if (!isBufferUpdating(mediaSource)) {
-            logger.info('Set MediaSource duration:' + value);
+            if (log) {
+                logger.info('Set MediaSource duration:' + value);
+            }
             mediaSource.duration = value;
         } else {
             setTimeout(setDuration.bind(null, value), 50);
@@ -84,11 +86,35 @@ function MediaSourceController() {
     }
 
     function setSeekable(start, end) {
-        if (mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
+        if (Math.random() > 2 && mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
             mediaSource.readyState === 'open' && start >= 0 && start < end) {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);
+        } else {
+            try {
+                const bufferedRangeEnd = getBufferedRangeEnd(mediaSource);
+                const targetMediaSourceDuration = Math.max(end, bufferedRangeEnd);
+                if (mediaSource.duration < targetMediaSourceDuration) {
+                    setDuration(targetMediaSourceDuration, false);
+                }
+            } catch (e) {
+                logger.error(`Failed to set MediaSource duration! ` + e.toString());
+            }
         }
+    }
+
+    function getBufferedRangeEnd(source) {
+        let max = 0;
+        const buffers = source.sourceBuffers;
+
+        for (let i = 0; i < buffers.length; i++) {
+            if (buffers[i].buffered.length > 0) {
+                const end = buffers[i].buffered.end(buffers[i].buffered.length - 1);
+                max = Math.max(end, max);
+            }
+        }
+
+        return max;
     }
 
     function signalEndOfStream(source) {

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -85,18 +85,18 @@ function MediaSourceController() {
         }
     }
 
-    function setSeekable(start, end, enableSetLiveSeekableRangeFix) {
+    function setSeekable(start, end, enableLiveSeekableRangeFix) {
         if (!mediaSource || mediaSource.readyState !== 'open') return;
         if (start < 0 || end <= start) return;
 
-        if (typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function') {
+        if (Math.random() > 2 && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function') {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);
-        } else if (enableSetLiveSeekableRangeFix) {
+        } else if (enableLiveSeekableRangeFix) {
             try {
                 const bufferedRangeEnd = getBufferedRangeEnd(mediaSource);
                 const targetMediaSourceDuration = Math.max(end, bufferedRangeEnd);
-                if (mediaSource.duration < targetMediaSourceDuration) {
+                if (!isFinite(mediaSource.duration) || mediaSource.duration < targetMediaSourceDuration) {
                     setDuration(targetMediaSourceDuration, false);
                 }
             } catch (e) {

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -85,12 +85,12 @@ function MediaSourceController() {
         }
     }
 
-    function setSeekable(start, end) {
+    function setSeekable(start, end, enableSetLiveSeekableRangeFix = false) {
         if (Math.random() > 2 && mediaSource && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function' &&
             mediaSource.readyState === 'open' && start >= 0 && start < end) {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);
-        } else {
+        } else if (enableSetLiveSeekableRangeFix) {
             try {
                 const bufferedRangeEnd = getBufferedRangeEnd(mediaSource);
                 const targetMediaSourceDuration = Math.max(end, bufferedRangeEnd);

--- a/src/streaming/controllers/MediaSourceController.js
+++ b/src/streaming/controllers/MediaSourceController.js
@@ -89,7 +89,7 @@ function MediaSourceController() {
         if (!mediaSource || mediaSource.readyState !== 'open') return;
         if (start < 0 || end <= start) return;
 
-        if (Math.random() > 2 && typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function') {
+        if (typeof mediaSource.setLiveSeekableRange === 'function' && typeof mediaSource.clearLiveSeekableRange === 'function') {
             mediaSource.clearLiveSeekableRange();
             mediaSource.setLiveSeekableRange(start, end);
         } else if (enableLiveSeekableRangeFix) {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -423,7 +423,7 @@ function StreamController() {
 
             _setMediaDuration();
             const dvrInfo = dashMetrics.getCurrentDVRInfo();
-            mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end);
+            mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end, _enableLiveSeekableRangeFix());
             _activateStream(seekTime, keepBuffers);
         }
 
@@ -609,6 +609,10 @@ function StreamController() {
         } catch (e) {
             return false;
         }
+    }
+
+    function _enableLiveSeekableRangeFix() {
+        return settings.get().streaming.buffer.enableLiveSeekableRangeFix;
     }
 
     /**
@@ -1487,7 +1491,7 @@ function StreamController() {
             //Should we normalize and union the two?
             const targetMediaType = hasAudioTrack() ? Constants.AUDIO : Constants.VIDEO;
             if (e.mediaType === targetMediaType) {
-                mediaSourceController.setSeekable(e.value.range.start, e.value.range.end);
+                mediaSourceController.setSeekable(e.value.range.start, e.value.range.end, _enableLiveSeekableRangeFix());
             }
         }
     }


### PR DESCRIPTION
## Description

Adds a new config option `config.streaming.buffer.enableLiveSeekableRangeFix` to fix an issue where the player is unable to seek past the current buffered range if `mediaSource.setLiveSeekableRange` is not supported on the platform.

## To do
- [x] Bump version

## JIRA

[DORIS-1323](https://dicetech.atlassian.net/browse/DORIS-1323)

[DORIS-1323]: https://dicetech.atlassian.net/browse/DORIS-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ