### PR TITLE
fix: customParametersModel undefined after reset called

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -422,7 +422,6 @@ function MediaPlayer() {
         }
         if (customParametersModel) {
             customParametersModel.reset();
-            customParametersModel = null;
         }
 
         settings.reset();


### PR DESCRIPTION
## Description
Merged https://github.com/Dash-Industry-Forum/dash.js/pull/3979 from official v4.4.1, for exception `Uncaught TypeError: Cannot read properties of null` after reset is called

## To do
 - [x] Bump version