### PR TITLE
Patch/doris 1703 expose default key id

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1145,7 +1145,7 @@ declare namespace dashjs {
         height: number;
         scanType: string;
         qualityIndex: number;
-        drmDefaultKeyId: string;
+        drmDefaultKeyId: string | null;
     }
 
     export interface FragmentRequest {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1145,6 +1145,7 @@ declare namespace dashjs {
         height: number;
         scanType: string;
         qualityIndex: number;
+        drmDefaultKeyId: string;
     }
 
     export interface FragmentRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.5.2",
+  "version": "4.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.5.1",
+    "version": "4.5.2",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.5.2",
+    "version": "4.5.1",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -444,12 +444,25 @@ function DashManifestModel() {
         const realRepresentations = processedRealAdaptation && Array.isArray(processedRealAdaptation.Representation_asArray) ? processedRealAdaptation.Representation_asArray : [];
 
         return realRepresentations.map((realRepresentation) => {
+            const contentProtection = this.getContentProtectionData(realRepresentation)
+            if (contentProtection) {
+                // Get the default key ID and apply it to all key systems
+                const keyIds = contentProtection.map(cp => this.getKID(cp)).filter(kid => kid !== null);
+                if (keyIds.length) {
+                    const keyId = keyIds[0];
+                    contentProtection.forEach(cp => {
+                        cp.keyId = keyId;
+                    });
+                }
+            }
+
             return {
                 bandwidth: realRepresentation.bandwidth,
                 width: realRepresentation.width || 0,
                 height: realRepresentation.height || 0,
                 scanType: realRepresentation.scanType || null,
-                id: realRepresentation.id || null
+                id: realRepresentation.id || null,
+                contentProtection
             };
         });
     }

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -444,15 +444,13 @@ function DashManifestModel() {
         const realRepresentations = processedRealAdaptation && Array.isArray(processedRealAdaptation.Representation_asArray) ? processedRealAdaptation.Representation_asArray : [];
 
         return realRepresentations.map((realRepresentation) => {
-            const contentProtection = this.getContentProtectionData(realRepresentation)
+            let drmDefaultKeyId = null;
+            const contentProtection = realRepresentation.ContentProtection_asArray || realRepresentation.ContentProtection;
             if (contentProtection) {
-                // Get the default key ID and apply it to all key systems
+                // Get the default key ID
                 const keyIds = contentProtection.map(cp => this.getKID(cp)).filter(kid => kid !== null);
                 if (keyIds.length) {
-                    const keyId = keyIds[0];
-                    contentProtection.forEach(cp => {
-                        cp.keyId = keyId;
-                    });
+                    drmDefaultKeyId = keyIds[0];
                 }
             }
 
@@ -462,7 +460,7 @@ function DashManifestModel() {
                 height: realRepresentation.height || 0,
                 scanType: realRepresentation.scanType || null,
                 id: realRepresentation.id || null,
-                contentProtection
+                drmDefaultKeyId
             };
         });
     }

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -46,7 +46,6 @@ import Debug from '../../core/Debug';
 import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 import {checkInteger} from '../utils/SupervisorTools';
 import MediaPlayerEvents from '../MediaPlayerEvents';
-import CommonEncryption from '../protection/CommonEncryption';
 
 const DEFAULT_VIDEO_BITRATE = 1000;
 const DEFAULT_AUDIO_BITRATE = 100;
@@ -805,14 +804,7 @@ function AbrController() {
             bitrateInfo.width = bitrateList[i].width;
             bitrateInfo.height = bitrateList[i].height;
             bitrateInfo.scanType = bitrateList[i].scanType;
-
-            const contentProtection = bitrateList[i].contentProtection ?? mediaInfo.contentProtection;
-            if (contentProtection) {
-                const cenc = CommonEncryption.findCencContentProtection(contentProtection);
-                if (cenc && cenc.keyId) {
-                    bitrateInfo.drmDefaultKeyId = cenc.keyId.replaceAll('-', '');
-                }
-            }
+            bitrateInfo.drmDefaultKeyId = bitrateList[i].drmDefaultKeyId;
 
             infoList.push(bitrateInfo);
         }

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -46,6 +46,7 @@ import Debug from '../../core/Debug';
 import {HTTPRequest} from '../vo/metrics/HTTPRequest';
 import {checkInteger} from '../utils/SupervisorTools';
 import MediaPlayerEvents from '../MediaPlayerEvents';
+import CommonEncryption from '../protection/CommonEncryption';
 
 const DEFAULT_VIDEO_BITRATE = 1000;
 const DEFAULT_AUDIO_BITRATE = 100;
@@ -804,6 +805,15 @@ function AbrController() {
             bitrateInfo.width = bitrateList[i].width;
             bitrateInfo.height = bitrateList[i].height;
             bitrateInfo.scanType = bitrateList[i].scanType;
+
+            const contentProtection = bitrateList[i].contentProtection ?? mediaInfo.contentProtection;
+            if (contentProtection) {
+                const cenc = CommonEncryption.findCencContentProtection(contentProtection);
+                if (cenc && cenc.keyId) {
+                    bitrateInfo.drmDefaultKeyId = cenc.keyId.replaceAll('-', '');
+                }
+            }
+
             infoList.push(bitrateInfo);
         }
 

--- a/src/streaming/vo/BitrateInfo.js
+++ b/src/streaming/vo/BitrateInfo.js
@@ -40,6 +40,7 @@ class BitrateInfo {
         this.height = null;
         this.scanType = null;
         this.qualityIndex = NaN;
+        this.drmDefaultKeyId = null;
     }
 }
 


### PR DESCRIPTION
## Description
Added patch to expose default key id of representations for bitrate filtering.

Issue had been raised to dash.js: [Multi-key DRM (3 video keys, 1 audio key) playback · Issue #3956 · Dash-Industry-Forum/dash.js](https://github.com/Dash-Industry-Forum/dash.js/issues/3956) 
This will be resolved officially in v5.0.0 [Refactor throughput and abr by dsilhavy · Pull Request #3776 · Dash-Industry-Forum/dash.js](https://github.com/Dash-Industry-Forum/dash.js/pull/3776). 
Our changes may be removed after that.
## To do
 - [x] Bump version