### PR TITLE
fix: Trigger SCTE35 events only for the current and subsequent periods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.5.2",
+    "version": "4.5.3",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/controllers/EventController.js
+++ b/src/streaming/controllers/EventController.js
@@ -219,18 +219,14 @@ function EventController() {
             if (values) {
                 for (let i = 0; i < values.length; i++) {
                     let event = values[i];
-                    const currentTime = playbackController.getTime();
-                    const duration = !isNaN(event.duration) ? event.duration : 0;
-                    if (!_eventHasExpired(currentTime, duration, event.calculatedPresentationTime)) {
-                        let result = _addOrUpdateEvent(event, inlineEvents[periodId], true);
+                    let result = _addOrUpdateEvent(event, inlineEvents[periodId], true);
 
-                        if (result === EVENT_HANDLED_STATES.ADDED) {
-                            logger.debug(`Added inline event with id ${event.id} from period ${periodId}`);
-                            // If we see the event for the first time we trigger it in onReceive mode
-                            _startEvent(event, MediaPlayerEvents.EVENT_MODE_ON_RECEIVE);
-                        } else if (result === EVENT_HANDLED_STATES.UPDATED) {
-                            logger.debug(`Updated inline event with id ${event.id} from period ${periodId}`);
-                        }
+                    if (result === EVENT_HANDLED_STATES.ADDED) {
+                        logger.debug(`Added inline event with id ${event.id} from period ${periodId}`);
+                        // If we see the event for the first time we trigger it in onReceive mode
+                        _startEvent(event, MediaPlayerEvents.EVENT_MODE_ON_RECEIVE);
+                    } else if (result === EVENT_HANDLED_STATES.UPDATED) {
+                        logger.debug(`Updated inline event with id ${event.id} from period ${periodId}`);
                     }
                 }
             }


### PR DESCRIPTION
### Description

From version 4.5, inline events are triggered for the current and subsequent periods. And for doris-plugin-dice-advertising, it needs to get all the scte35 messages at the beginning.