### PR TITLE
fix: account for latency in AbandonRequestsRule

### DIFF
--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -139,7 +139,10 @@ function AbandonRequestsRule(config) {
                     if (timeRemainingMilliseconds > estimatedOtherTimeRemainingMilliseconds) {
                         switchRequest.quality = newQuality;
                         switchRequest.reason.throughput = fragmentInfo.measuredBandwidthInKbps;
+                        switchRequest.reason.throughputValues = throughputArray[mediaType];
                         switchRequest.reason.fragmentID = fragmentInfo.id;
+                        switchRequest.reason.latency = estimatedLatency;
+                        switchRequest.reason.bufferLevel = dashMetrics.getCurrentBufferLevel(mediaType);
                         abandonDict[fragmentInfo.id] = fragmentInfo;
                         logger.debug('[' + mediaType + '] frag id',fragmentInfo.id,' is asking to abandon and switch to quality to ', newQuality, ' measured bandwidth was', fragmentInfo.measuredBandwidthInKbps);
                         delete fragmentDict[mediaType][fragmentInfo.id];

--- a/src/streaming/rules/abr/InsufficientBufferRule.js
+++ b/src/streaming/rules/abr/InsufficientBufferRule.js
@@ -115,7 +115,7 @@ function InsufficientBufferRule(config) {
             const bitrate = throughput * (bufferLevel / fragmentDuration) * INSUFFICIENT_BUFFER_SAFETY_FACTOR;
 
             switchRequest.quality = abrController.getQualityForBitrate(mediaInfo, bitrate, streamId, latency);
-            switchRequest.reason = 'InsufficientBufferRule: being conservative to avoid immediate rebuffering';
+            switchRequest.reason = {name: 'InsufficientBufferRule', reason: 'Being conservative to avoid immediate rebuffering', bufferLevel:bufferLevel, throughput: throughput, latency: latency, bitrate: bitrate};
         }
 
         return switchRequest;


### PR DESCRIPTION
## Description

- Account for latency in `AbandonRequestsRule`. Stops the rule from firing when abandoning the request would not benefit buffering due to the added latency of requesting a new fragment.