### PR TITLE
fix: Segmented WebVTT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.5.4",
+    "version": "4.5.5",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -596,12 +596,10 @@ function DashManifestModel() {
                         }
                     } else {
                         const mimeType = processedRealAdaptation.mimeType || getMimeType(processedRealAdaptation);
-                        if (
-                            getIsText(processedRealAdaptation) &&
+                        if (getIsText(processedRealAdaptation) &&
                             getIsFragmented(processedRealAdaptation) &&
                             mimeType &&
-                            mimeType.indexOf('application/mp4') === -1
-                        ) {
+                            mimeType.indexOf('application/mp4') === -1) {
                             voRepresentation.range = 0;
                         }
                     }

--- a/src/dash/models/DashManifestModel.js
+++ b/src/dash/models/DashManifestModel.js
@@ -594,11 +594,16 @@ function DashManifestModel() {
                             // initialization source url will be determined from
                             // BaseURL when resolved at load time.
                         }
-                    } else if (getIsText(processedRealAdaptation) &&
-                        getIsFragmented(processedRealAdaptation) &&
-                        processedRealAdaptation.mimeType &&
-                        processedRealAdaptation.mimeType.indexOf('application/mp4') === -1) {
-                        voRepresentation.range = 0;
+                    } else {
+                        const mimeType = processedRealAdaptation.mimeType || getMimeType(processedRealAdaptation);
+                        if (
+                            getIsText(processedRealAdaptation) &&
+                            getIsFragmented(processedRealAdaptation) &&
+                            mimeType &&
+                            mimeType.indexOf('application/mp4') === -1
+                        ) {
+                            voRepresentation.range = 0;
+                        }
                     }
 
                     if (segmentInfo.hasOwnProperty(DashConstants.TIMESCALE)) {

--- a/src/streaming/SourceBufferSink.js
+++ b/src/streaming/SourceBufferSink.js
@@ -136,7 +136,7 @@ function SourceBufferSink(config) {
 
         } catch (e) {
             // Note that in the following, the quotes are open to allow for extra text after stpp and wvtt
-            if ((mediaInfo.type == constants.TEXT && !mediaInfo.isFragmented) || (codec.indexOf('codecs="stpp') !== -1) || (codec.indexOf('codecs="vtt') !== -1)) {
+            if ((mediaInfo.type == constants.TEXT && !mediaInfo.isFragmented) || (codec.indexOf('codecs="stpp') !== -1) || (codec.indexOf('codecs="vtt') !== -1) || (codec.indexOf('text/vtt') !== -1)) {
                 return _initializeForText(streamInfo);
             }
             return Promise.reject(e);

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -569,8 +569,9 @@ function TextTracks(config) {
     function cueInTrack(track, cue) {
         if (!track.cues) return false;
         for (let i = 0; i < track.cues.length; i++) {
-            if ((track.cues[i].startTime === cue.startTime) &&
-                (track.cues[i].endTime === cue.endTime)) {
+            if (track.cues[i].startTime === cue.startTime &&
+                track.cues[i].endTime === cue.endTime &&
+                track.cues[i].text === cue.text) {
                 return true;
             }
         }


### PR DESCRIPTION
## Description

- Cherry-picked fix for text source buffer fallback https://github.com/Dash-Industry-Forum/dash.js/pull/4265
- Fixed issue where text adaptations were not identified as such, if the mimeType was set on the representation only.
- Fixed issue with caption deduplication logic, where 2 lines of captions where both have the same start + end time with different text got deduplicated. 