### PR TITLE
Fix/doris 2303 configurable abandon request grace period

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -290,6 +290,7 @@ declare namespace dashjs {
                     droppedFramesRule?: boolean,
                     abandonRequestsRule?: boolean
                 },
+                abandonRequestsRuleGraceTimeThreshold?: number;
                 bandwidthSafetyFactor?: number;
                 useDefaultABRRules?: boolean;
                 useDeadTimeLatency?: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dashjs",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.5.6",
+    "version": "4.5.7",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -912,6 +912,7 @@ function Settings() {
                     droppedFramesRule: true,
                     abandonRequestsRule: true
                 },
+                abandonRequestsRuleGraceTimeThreshold: 500,
                 bandwidthSafetyFactor: 0.9,
                 useDefaultABRRules: true,
                 useDeadTimeLatency: true,

--- a/src/streaming/rules/abr/AbandonRequestsRule.js
+++ b/src/streaming/rules/abr/AbandonRequestsRule.js
@@ -36,7 +36,6 @@ function AbandonRequestsRule(config) {
 
     config = config || {};
     const ABANDON_MULTIPLIER = 1.8;
-    const GRACE_TIME_THRESHOLD = 500;
     const MIN_LENGTH_TO_AVERAGE = 5;
 
     const context = this.context;
@@ -109,7 +108,7 @@ function AbandonRequestsRule(config) {
             }
 
             if (throughputArray[mediaType].length >= MIN_LENGTH_TO_AVERAGE &&
-                fragmentInfo.elapsedTime > GRACE_TIME_THRESHOLD &&
+                fragmentInfo.elapsedTime > settings.get().streaming.abr.abandonRequestsRuleGraceTimeThreshold &&
                 fragmentInfo.bytesLoaded < fragmentInfo.bytesTotal) {
 
                 const totalSampledValue = throughputArray[mediaType].reduce((a, b) => a + b, 0);


### PR DESCRIPTION
Make the grace period in `AbandonRequestsRule` configurable for poor CDN edges where the transmission starts very slowly. 

Image depicts a case where the transmission starts slowly, leading to an initial high estimate which can trigger this rule (shown by the red highlighted area).

Increasing the grace period will cause the rule to kick in later, which will handle these scenarios better, but could have a potential negative impact on the players ability to react to sudden network changes.

![image](https://github.com/DiceTechnology/dash.js/assets/34451173/000a13d9-3235-40f6-ab67-22a439191e89)
