### PR TITLE
Fix/doris 2781 seek to start date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.6",
+    "version": "4.7.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.6",
+            "version": "4.7.7",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.6",
+    "version": "4.7.7",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -104,13 +104,6 @@ function VideoModel() {
                     return;
                 }
 
-                // We don't set the same currentTime because it can cause firing unexpected Pause event in IE11
-                // providing playbackRate property equals to zero.
-                if (element.currentTime === _currentTime) {
-                    _currentTime = NaN;
-                    return;
-                }
-
                 // TODO Despite the fact that MediaSource 'open' event has been fired IE11 cannot set videoElement.currentTime
                 // immediately (it throws InvalidStateError). It seems that this is related to videoElement.readyState property
                 // Initially it is 0, but soon after 'open' event it goes to 1 and setting currentTime is allowed. Chrome allows to


### PR DESCRIPTION
## Description

Remove IE11 patch that prevents seeking if the element is at the same position. This is because `seekTarget` in the `PlaybackController` is never reset back to `NaN` in the `_onPlaybackSeeking` method causing the PlaybackController to ignore the request because `if (time === currentTime) return;`.

For us this means seeking to the startDate does not work (premier-vods).

## JIRA

[DORIS-2781](https://dicetech.atlassian.net/browse/DORIS-2781)

[DORIS-2781]: https://dicetech.atlassian.net/browse/DORIS-2781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ