### PR TITLE
Fix/doris 2812 bandwidth estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.7",
+    "version": "4.7.8",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -108,6 +108,7 @@ function AbrController() {
 
         eventBus.on(MediaPlayerEvents.QUALITY_CHANGE_RENDERED, _onQualityChangeRendered, instance);
         eventBus.on(MediaPlayerEvents.METRIC_ADDED, _onMetricAdded, instance);
+        eventBus.on(Events.LOADING_COMPLETED, _onFragmentLoadCompleted, instance);
         eventBus.on(Events.LOADING_PROGRESS, _onFragmentLoadProgress, instance);
     }
 
@@ -219,6 +220,7 @@ function AbrController() {
         resetInitialSettings();
 
         eventBus.off(Events.LOADING_PROGRESS, _onFragmentLoadProgress, instance);
+        eventBus.off(Events.LOADING_COMPLETED, _onFragmentLoadCompleted, instance);
         eventBus.off(MediaPlayerEvents.QUALITY_CHANGE_RENDERED, _onQualityChangeRendered, instance);
         eventBus.off(MediaPlayerEvents.METRIC_ADDED, _onMetricAdded, instance);
 
@@ -262,6 +264,16 @@ function AbrController() {
     function checkConfig() {
         if (!domStorage || !domStorage.hasOwnProperty('getSavedBitrateSettings')) {
             throw new Error(Constants.MISSING_CONFIG_ERROR);
+        }
+    }
+
+    function _onFragmentLoadCompleted(e) {
+        const type = e.request.mediaType;
+        const streamId = e.streamId;
+        if (type && streamProcessorDict[streamId] && streamProcessorDict[streamId][type]) {
+            const streamInfo = streamProcessorDict[streamId][type].getStreamInfo();
+            const isDynamic = streamInfo && streamInfo.manifestInfo && streamInfo.manifestInfo.isDynamic;
+            _saveBandwidthEstimate(type, isDynamic)
         }
     }
 
@@ -765,10 +777,14 @@ function AbrController() {
                 },
                 { streamId: streamInfo.id, mediaType: type }
             );
-            const bitrate = throughputHistory.getAverageThroughput(type, isDynamic);
-            if (!isNaN(bitrate)) {
-                domStorage.setSavedBitrateSettings(type, bitrate);
-            }
+            _saveBandwidthEstimate(type, isDynamic);
+        }
+    }
+
+    function _saveBandwidthEstimate(type, isDynamic) {
+        const bitrate = throughputHistory.getAverageThroughput(type, isDynamic);
+        if (!isNaN(bitrate)) {
+            domStorage.setSavedBitrateSettings(type, bitrate);
         }
     }
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -269,12 +269,13 @@ function AbrController() {
 
     function _onFragmentLoadCompleted(e) {
         const type = e.request.mediaType;
-        const streamId = e.streamId;
-        if (type && streamProcessorDict[streamId] && streamProcessorDict[streamId][type]) {
-            const streamInfo = streamProcessorDict[streamId][type].getStreamInfo();
-            const isDynamic = streamInfo && streamInfo.manifestInfo && streamInfo.manifestInfo.isDynamic;
-            _saveBandwidthEstimate(type, isDynamic)
+        if (!type) {
+            return;
         }
+        const isDynamic = !!e.request.mediaInfo?.streamInfo?.manifestInfo?.isDynamic;
+
+        console.log(`Persisting estimate on frag load complete for type: ${type}, isDynamic: ${isDynamic}`);
+        _saveBandwidthEstimate(type, isDynamic)
     }
 
     /**
@@ -758,7 +759,6 @@ function AbrController() {
     function _changeQuality(type, oldQuality, newQuality, maxIdx, reason, streamId) {
         if (type && streamProcessorDict[streamId] && streamProcessorDict[streamId][type]) {
             const streamInfo = streamProcessorDict[streamId][type].getStreamInfo();
-            const isDynamic = streamInfo && streamInfo.manifestInfo && streamInfo.manifestInfo.isDynamic;
             const bufferLevel = dashMetrics.getCurrentBufferLevel(type);
             logger.info('Stream ID: ' + streamId + ' [' + type + '] switch from ' + oldQuality + ' to ' + newQuality + '/' + maxIdx + ' (buffer: ' + bufferLevel + ') ' + (reason ? JSON.stringify(reason) : '.'));
 
@@ -777,7 +777,6 @@ function AbrController() {
                 },
                 { streamId: streamInfo.id, mediaType: type }
             );
-            _saveBandwidthEstimate(type, isDynamic);
         }
     }
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -273,8 +273,6 @@ function AbrController() {
             return;
         }
         const isDynamic = !!e.request.mediaInfo?.streamInfo?.manifestInfo?.isDynamic;
-
-        console.log(`Persisting estimate on frag load complete for type: ${type}, isDynamic: ${isDynamic}`);
         _saveBandwidthEstimate(type, isDynamic)
     }
 

--- a/src/streaming/rules/ThroughputHistory.js
+++ b/src/streaming/rules/ThroughputHistory.js
@@ -76,10 +76,14 @@ function ThroughputHistory(config) {
     }
 
     function isCachedResponse(mediaType, latencyMs, downloadTimeMs) {
+        // Include latency + download time to make sure tiny segments are not misclassified as cached.
+        // This patch can be removed once upgraded to dash.js 5, as it has a better implementation
+        // using ResponseTiming API.
+        const cacheReferenceTime = latencyMs + downloadTimeMs;
         if (mediaType === Constants.VIDEO) {
-            return downloadTimeMs < settings.get().streaming.cacheLoadThresholds[Constants.VIDEO];
+            return cacheReferenceTime < settings.get().streaming.cacheLoadThresholds[Constants.VIDEO];
         } else if (mediaType === Constants.AUDIO) {
-            return downloadTimeMs < settings.get().streaming.cacheLoadThresholds[Constants.AUDIO];
+            return cacheReferenceTime < settings.get().streaming.cacheLoadThresholds[Constants.AUDIO];
         }
     }
 


### PR DESCRIPTION
## Description

- Save bandwidth estimate on fragment load completion instead of level switch.
  - Fixes issues on `SegmentBase` streams where buffering the init-ranges can negatively impact the persisted bandwidth estimate, and following views can start on lowest quality.
  - Improves bandwidth persistence if videos have varying bitrate ladders.
- Updated cached response detection to include latency as well. Dash v5 implements this in a similar way, with the addition of the Resource Timing API.
  - This fixes issues where if low quality segments are buffered rapidly, they wouldn't alter the throughput estimate leading to the player getting stuck on low quality with fast network. 