### PR TITLE
Fix/doris 3094 embedded fragmented subs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1049,6 +1049,7 @@ declare namespace dashjs {
                 scheduleWhilePaused?: boolean
             },
             text?: {
+                appendFragmentedCuesWhenTrackModeDisabled?: boolean,
                 defaultEnabled?: boolean,
                 dispatchForManualRendering?: boolean,
                 extendSegmentedCues?: boolean,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.7",
+    "version": "4.7.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.7",
+            "version": "4.7.10",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.9",
+    "version": "4.7.10",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -488,6 +488,9 @@ import Events from './events/Events';
 
 /**
  * @typedef {Object} Text
+ * @property {boolean} [appendFragmentedCuesWhenTrackModeDisabled=true]
+ * Whether fragment cues should be appended to the TextTrack when the track mode is set to disabled.
+ * Fragment cues are fetched once. This ensures we don't miss them when the track mode is set to disabled.
  * @property {boolean} [defaultEnabled=true]
  * Enable/disable subtitle rendering by default.
  * @property {boolean} [dispatchForManualRendering=false]
@@ -974,6 +977,7 @@ function Settings() {
                 scheduleWhilePaused: true
             },
             text: {
+                appendFragmentedCuesWhenTrackModeDisabled: true,
                 defaultEnabled: true,
                 dispatchForManualRendering: false,
                 extendSegmentedCues: true,

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -542,7 +542,12 @@ function TextTracks(config) {
                                     }
                                 }
                             } else {
-                                if (track.mode !== Constants.TEXT_DISABLED) {
+                                const isFragmented = this.getCurrentTrackInfo()?.isFragmented;
+                                const appendFragmentedCuesWhenTrackModeDisabled = settings.get().streaming.text.appendFragmentedCuesWhenTrackModeDisabled;
+
+                                // If disabled, add fragment cues as they'll be downloaded once.
+                                // If you miss them, they won't be downloaded again.
+                                if (track.mode !== Constants.TEXT_DISABLED || (appendFragmentedCuesWhenTrackModeDisabled && isFragmented)) {
                                     track.addCue(cue);
                                 }
                             }


### PR DESCRIPTION
## Description

If `track.mode = disabled` cues will not be appended to the TextTrack. This is problematic for embedded subs that are delivered as fragments, as they are only downloaded once by dash.js.

## Jira ticket

[DORIS-3094](https://dicetech.atlassian.net/browse/DORIS-3094)

[DORIS-3094]: https://dicetech.atlassian.net/browse/DORIS-3094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ