### PR TITLE
fix: CC does not display immediately when using dash.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.10",
+    "version": "4.7.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.10",
+    "version": "4.7.11",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -547,7 +547,7 @@ function TextTracks(config) {
 
                                 // If disabled, add fragment cues as they'll be downloaded once.
                                 // If you miss them, they won't be downloaded again.
-                                if (track.mode !== Constants.TEXT_DISABLED || (appendFragmentedCuesWhenTrackModeDisabled && isFragmented) || track.kind === 'captions') {
+                                if (track.mode !== Constants.TEXT_DISABLED || (appendFragmentedCuesWhenTrackModeDisabled && (isFragmented || track.kind === 'captions'))) {
                                     track.addCue(cue);
                                 }
                             }

--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -547,7 +547,7 @@ function TextTracks(config) {
 
                                 // If disabled, add fragment cues as they'll be downloaded once.
                                 // If you miss them, they won't be downloaded again.
-                                if (track.mode !== Constants.TEXT_DISABLED || (appendFragmentedCuesWhenTrackModeDisabled && isFragmented)) {
+                                if (track.mode !== Constants.TEXT_DISABLED || (appendFragmentedCuesWhenTrackModeDisabled && isFragmented) || track.kind === 'captions') {
                                     track.addCue(cue);
                                 }
                             }


### PR DESCRIPTION
# Description

CC subtitles will not be added to the track, when downloading a segment and the texttrack is not selected.

[Test Player](https://doris-reference-player.s3.eu-west-1.amazonaws.com/gene-player/cc/index.html#eyJkaWNlT3B0aW9ucyI6eyJhcGlLZXkiOiIiLCJhdXRoVG9rZW4iOiIiLCJiYXNlVXJsIjoiIiwiYmVhY29uRW5kcG9pbnQiOiIiLCJlbmFibGVEYXNoIjp0cnVlLCJlbmFibGVIbHMiOnRydWUsImVuYWJsZUhsc1dpZGV2aW5lIjp0cnVlLCJpZCI6IiIsInN0cmVhbVR5cGUiOiJWT0QiLCJyZWFsbSI6IiIsInJlZnJlc2hUb2tlbiI6IiIsIndpdGhWNUVuZHBvaW50IjpmYWxzZSwid2l0aENsaWVudE1hY3JvcyI6ZmFsc2V9LCJzcmNVcmwiOiJodHRwczovL3NhbXBsZS12aWRlb3Mtenlya3AybmouczMuZXUtd2VzdC0xLmFtYXpvbmF3cy5jb20vdGlja2V0cy9ET1JJUy0yOTg0L21hbmlmZXN0Lm1wZCJ9)

# Jira ticket
[DORIS-2984](https://dicetech.atlassian.net/browse/DORIS-2984)

[DORIS-2984]: https://dicetech.atlassian.net/browse/DORIS-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ