### PR TITLE
Fix/doris 3330 filter out unsupported tracks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2895,7 +2895,7 @@ declare namespace dashjs {
 
         setProtectionData(data: object): void;
 
-        getSupportedKeySystemsFromContentProtection(cps: object[]): KeySystemInfo[]; 
+        getSupportedKeySystemMetadataFromContentProtection(cps: object[]): KeySystemInfo[]; 
 
         getKeySystems(): any[];
 
@@ -2925,7 +2925,7 @@ declare namespace dashjs {
 
         getKeySystemBySystemString(systemString: string): KeySystem | null;
 
-        getSupportedKeySystemsFromContentProtection(cps: object[], protDataSet: ProtectionDataSet, sessionType: string): object[]; //it says protDataSet but param is marked as protData
+        getSupportedKeySystemMetadataFromContentProtection(cps: object[], protDataSet: ProtectionDataSet, sessionType: string): object[]; //it says protDataSet but param is marked as protData
 
         getSupportedKeySystemsFromSegmentPssh(initData: ArrayBuffer, protDataSet: ProtectionDataSet, sessionType: string): object[];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.11",
+    "version": "4.7.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.10",
+            "version": "4.7.12",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.11",
+    "version": "4.7.12",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -73,7 +73,7 @@ import Events from './events/Events';
  *            parseInbandPrft: false,
  *            capabilities: {
  *               filterUnsupportedEssentialProperties: true,
- *               useMediaCapabilitiesApi: false,
+ *               useMediaCapabilitiesApi: true,
  *               replaceCodecs: []
  *            },
  *            timeShiftBuffer: {
@@ -596,7 +596,7 @@ import Events from './events/Events';
  * @typedef {Object} Capabilities
  * @property {boolean} [filterUnsupportedEssentialProperties=true]
  * Enable to filter all the AdaptationSets and Representations which contain an unsupported \<EssentialProperty\> element.
- * @property {boolean} [useMediaCapabilitiesApi=false]
+ * @property {boolean} [useMediaCapabilitiesApi=true]
  * Enable to use the MediaCapabilities API to check whether codecs are supported. If disabled MSE.isTypeSupported will be used instead.
  * @property {Array.<[string, string]>} [replaceCodecs=[]]
  * List of codecs to be replaced.
@@ -902,7 +902,7 @@ function Settings() {
             enableManifestTimescaleMismatchFix: false,
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
-                useMediaCapabilitiesApi: false,
+                useMediaCapabilitiesApi: true,
                 replaceCodecs: []
             },
             timeShiftBuffer: {

--- a/src/dash/parser/maps/RepresentationBaseValuesMap.js
+++ b/src/dash/parser/maps/RepresentationBaseValuesMap.js
@@ -37,7 +37,7 @@ import DashConstants from '../../constants/DashConstants';
 class RepresentationBaseValuesMap extends MapNode {
     constructor() {
         const commonProperties = [
-            DashConstants.PROFILES, DashConstants.WIDTH, DashConstants.HEIGHT, DashConstants.SAR, DashConstants.FRAMERATE, DashConstants.AUDIO_SAMPLING_RATE, DashConstants.MIME_TYPE, DashConstants.SEGMENT_PROFILES, DashConstants.CODECS, DashConstants.MAXIMUM_SAP_PERIOD, DashConstants.START_WITH_SAP, DashConstants.MAX_PLAYOUT_RATE, DashConstants.CODING_DEPENDENCY, DashConstants.SCAN_TYPE, DashConstants.FRAME_PACKING, DashConstants.AUDIO_CHANNEL_CONFIGURATION, DashConstants.CONTENT_PROTECTION, DashConstants.ESSENTIAL_PROPERTY, DashConstants.ESSENTIAL_PROPERTY+'_asArray', DashConstants.SUPPLEMENTAL_PROPERTY, DashConstants.INBAND_EVENT_STREAM
+            DashConstants.PROFILES, DashConstants.WIDTH, DashConstants.HEIGHT, DashConstants.SAR, DashConstants.FRAMERATE, DashConstants.AUDIO_SAMPLING_RATE, DashConstants.MIME_TYPE, DashConstants.SEGMENT_PROFILES, DashConstants.CODECS, DashConstants.MAXIMUM_SAP_PERIOD, DashConstants.START_WITH_SAP, DashConstants.MAX_PLAYOUT_RATE, DashConstants.CODING_DEPENDENCY, DashConstants.SCAN_TYPE, DashConstants.FRAME_PACKING, DashConstants.AUDIO_CHANNEL_CONFIGURATION, DashConstants.CONTENT_PROTECTION, DashConstants.CONTENT_PROTECTION+'_asArray', DashConstants.ESSENTIAL_PROPERTY, DashConstants.ESSENTIAL_PROPERTY+'_asArray', DashConstants.SUPPLEMENTAL_PROPERTY, DashConstants.INBAND_EVENT_STREAM
         ];
 
         super(DashConstants.ADAPTATION_SET, commonProperties, [

--- a/src/dash/parser/objectiron.js
+++ b/src/dash/parser/objectiron.js
@@ -48,12 +48,23 @@ function ObjectIron(mappers) {
                 if (child[property.name]) {
                     // check to see if we should merge
                     if (property.merge) {
-                        const parentValue = parent[property.name];
-                        const childValue = child[property.name];
+                        let parentValue = parent[property.name];
+                        let childValue = child[property.name];
 
                         // complex objects; merge properties
                         if (typeof parentValue === 'object' && typeof childValue === 'object') {
-                            mergeValues(parentValue, childValue);
+                            // TODO: This can be removed in dashjs@5
+                            // Cover and edge-case where AdaptationSet@ContentProtection is an array,
+                            // and RepresentationSet@ContentProtection is an object.
+                            const isParentArray = Array.isArray(parentValue);
+                            const isChildArray = Array.isArray(childValue);
+                            if (isParentArray || isChildArray) {
+                                child[property.name] =
+                                    (isChildArray ? childValue : [childValue])
+                                        .concat(isParentArray ? parentValue : [parentValue])
+                            } else {
+                                mergeValues(parentValue, childValue);
+                            }
                         }
                         // simple objects; merge them together
                         else {

--- a/src/mss/MssFragmentMoovProcessor.js
+++ b/src/mss/MssFragmentMoovProcessor.js
@@ -140,7 +140,7 @@ function MssFragmentMoovProcessor(config) {
         createTrexBox(mvex);
 
         if (contentProtection && protectionController) {
-            let supportedKS = protectionController.getSupportedKeySystemsFromContentProtection(contentProtection);
+            let supportedKS = protectionController.getSupportedKeySystemMetadataFromContentProtection(contentProtection);
             createProtectionSystemSpecificHeaderBox(moov, supportedKS);
         }
     }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2189,6 +2189,7 @@ function MediaPlayer() {
             customParametersModel,
             adapter,
             settings,
+            protectionController,
             manifestModel,
             errHandler
         });
@@ -2304,6 +2305,9 @@ function MediaPlayer() {
             Errors.extend(Protection.errors);
             if (!capabilities) {
                 capabilities = Capabilities(context).getInstance();
+                capabilities.setConfig({
+                    settings
+                })
             }
             protectionController = protection.createProtectionSystem({
                 debug,

--- a/src/streaming/protection/controllers/ProtectionController.js
+++ b/src/streaming/protection/controllers/ProtectionController.js
@@ -104,7 +104,7 @@ function ProtectionController(config) {
     }
 
     function checkConfig() {
-        if (!eventBus || !eventBus.hasOwnProperty('on') || !protectionKeyController || !protectionKeyController.hasOwnProperty('getSupportedKeySystemsFromContentProtection')) {
+        if (!eventBus || !eventBus.hasOwnProperty('on') || !protectionKeyController || !protectionKeyController.hasOwnProperty('getSupportedKeySystemMetadataFromContentProtection')) {
             throw new Error('Missing config parameter(s)');
         }
     }
@@ -142,7 +142,7 @@ function ProtectionController(config) {
 
         let supportedKeySystems = [];
         mediaInfoArr.forEach((mInfo) => {
-            const currentKs = protectionKeyController.getSupportedKeySystemsFromContentProtection(mInfo.contentProtection, protDataSet, sessionType);
+            const currentKs = protectionKeyController.getSupportedKeySystemMetadataFromContentProtection(mInfo.contentProtection, protDataSet, sessionType);
             // We assume that the same key systems are signaled for each AS. We can use the first entry we found
             if (currentKs.length > 0) {
                 if (supportedKeySystems.length === 0) {
@@ -453,9 +453,9 @@ function ProtectionController(config) {
      * @instance
      * @ignore
      */
-    function getSupportedKeySystemsFromContentProtection(cps) {
+    function getSupportedKeySystemMetadataFromContentProtection(cps) {
         checkConfig();
-        return protectionKeyController.getSupportedKeySystemsFromContentProtection(cps, protDataSet, sessionType);
+        return protectionKeyController.getSupportedKeySystemMetadataFromContentProtection(cps, protDataSet, sessionType);
     }
 
     /**
@@ -1177,7 +1177,7 @@ function ProtectionController(config) {
         setSessionType,
         setRobustnessLevel,
         setProtectionData,
-        getSupportedKeySystemsFromContentProtection,
+        getSupportedKeySystemMetadataFromContentProtection,
         getKeySystems,
         setKeySystems,
         stop,

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -210,17 +210,15 @@ function ProtectionKeyController() {
         let supportedKS = [];
 
         if (cps) {
-            const keys = Object.keys(cps).filter(key => Number.isInteger(+key));
-            const elements = keys.map(key => cps[key]);
-            const cencContentProtection = CommonEncryption.findCencContentProtection(elements); // Expects an array, whereas cps is an object, hence conversion above.
+            const cencContentProtection = CommonEncryption.findCencContentProtection(cps);
             for (ksIdx = 0; ksIdx < keySystems.length; ++ksIdx) {
                 ks = keySystems[ksIdx];
 
                 // Get protection data that applies for current key system
                 const protData = _getProtDataForKeySystem(ks.systemString, protDataSet);
 
-                for (cpIdx = 0; cpIdx < elements.length; ++cpIdx) {
-                    cp = elements[cpIdx];
+                for (cpIdx = 0; cpIdx < cps.length; ++cpIdx) {
+                    cp = cps[cpIdx];
                     if (cp.schemeIdUri.toLowerCase() === ks.schemeIdURI) {
                         // Look for DRM-specific ContentProtection
                         let initData = ks.getInitData(cp, cencContentProtection);

--- a/src/streaming/protection/controllers/ProtectionKeyController.js
+++ b/src/streaming/protection/controllers/ProtectionKeyController.js
@@ -205,20 +205,22 @@ function ProtectionKeyController() {
      * @memberof module:ProtectionKeyController
      * @instance
      */
-    function getSupportedKeySystemsFromContentProtection(cps, protDataSet, sessionType) {
+    function getSupportedKeySystemMetadataFromContentProtection(cps, protDataSet, sessionType) {
         let cp, ks, ksIdx, cpIdx;
         let supportedKS = [];
 
         if (cps) {
-            const cencContentProtection = CommonEncryption.findCencContentProtection(cps);
+            const keys = Object.keys(cps).filter(key => Number.isInteger(+key));
+            const elements = keys.map(key => cps[key]);
+            const cencContentProtection = CommonEncryption.findCencContentProtection(elements); // Expects an array, whereas cps is an object, hence conversion above.
             for (ksIdx = 0; ksIdx < keySystems.length; ++ksIdx) {
                 ks = keySystems[ksIdx];
 
                 // Get protection data that applies for current key system
                 const protData = _getProtDataForKeySystem(ks.systemString, protDataSet);
 
-                for (cpIdx = 0; cpIdx < cps.length; ++cpIdx) {
-                    cp = cps[cpIdx];
+                for (cpIdx = 0; cpIdx < elements.length; ++cpIdx) {
+                    cp = elements[cpIdx];
                     if (cp.schemeIdUri.toLowerCase() === ks.schemeIdURI) {
                         // Look for DRM-specific ContentProtection
                         let initData = ks.getInitData(cp, cencContentProtection);
@@ -385,7 +387,7 @@ function ProtectionKeyController() {
         getKeySystems,
         setKeySystems,
         getKeySystemBySystemString,
-        getSupportedKeySystemsFromContentProtection,
+        getSupportedKeySystemMetadataFromContentProtection,
         getSupportedKeySystemsFromSegmentPssh,
         getLicenseServerModelInstance,
         processClearKeyLicenseRequest,

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -51,6 +51,22 @@ export function supportsMediaSource() {
     return (hasManagedMediaSource || hasWebKit || hasMediaSource);
 }
 
+/**
+ * Reflect a promise so it never rejects.
+ *
+ * @param {Promise} promise
+ */
+async function reflectPromise(promise) {
+    return promise.then(
+        (value) => {
+            return { status: 'fulfilled', value };
+        },
+        (reason) => {
+            return { status: 'rejected', reason };
+        }
+    );
+}
+
 function Capabilities() {
 
     let instance,
@@ -175,7 +191,7 @@ function Capabilities() {
                 return navigator.mediaCapabilities.decodingInfo(configuration)
             })
 
-            Promise.allSettled(promises)
+            Promise.all(promises.map(reflectPromise))
                 .then((results) => {
                     const isSupported = results.some((singleResult) => {
                         return singleResult.status === 'fulfilled' && singleResult.value && singleResult.value.supported

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -156,38 +156,99 @@ function Capabilities() {
 
     /**
      * Check codec support using the MediaCapabilities API
-     * @param {object} config
+     * @param {object} inputConfig
      * @param {string} type
      * @return {Promise<boolean>}
      * @private
      */
-    function _checkCodecWithMediaCapabilities(config, type) {
+    function _checkCodecWithMediaCapabilities(inputConfig, type) {
         return new Promise((resolve) => {
 
-            if (!config || !config.codec) {
+            if (!inputConfig || !inputConfig.codec || (inputConfig.isSupported === false)) {
                 resolve(false);
                 return;
             }
 
-            const configuration = {
-                type: 'media-source'
-            };
+            const genericMediaCapabilitiesConfiguration = _getGenericMediaCapabilitiesConfig(inputConfig, type);
+            const configurationsToTest = _enhanceGenericConfigurationWithKeySystemConfiguration(genericMediaCapabilitiesConfiguration, inputConfig)
+            const promises = configurationsToTest.map((configuration) => {
+                return navigator.mediaCapabilities.decodingInfo(configuration)
+            })
 
-            configuration[type] = {};
-            configuration[type].contentType = config.codec;
-            configuration[type].width = config.width;
-            configuration[type].height = config.height;
-            configuration[type].bitrate = parseInt(config.bitrate);
-            configuration[type].framerate = parseFloat(config.framerate);
-
-            navigator.mediaCapabilities.decodingInfo(configuration)
-                .then((result) => {
-                    resolve(result.supported);
+            Promise.allSettled(promises)
+                .then((results) => {
+                    const isSupported = results.some((singleResult) => {
+                        return singleResult.status === 'fulfilled' && singleResult.value && singleResult.value.supported
+                    })
+                    resolve(isSupported);
                 })
-                .catch(() => {
-                    resolve(false);
-                });
         });
+    }
+
+    function _getGenericMediaCapabilitiesConfig(inputConfig, type) {
+        let configuration
+
+        if (type === Constants.VIDEO) {
+            configuration = _getGenericMediaCapabilitiesVideoConfig(inputConfig)
+        } else if (type === Constants.AUDIO) {
+            configuration = _getGenericMediaCapabilitiesAudioConfig(inputConfig)
+        }
+
+        configuration[type].contentType = inputConfig.codec;
+        configuration[type].bitrate = parseInt(inputConfig.bitrate);
+        configuration.type = 'media-source';
+
+        return configuration
+    }
+
+    function _getGenericMediaCapabilitiesVideoConfig(inputConfig) {
+        const configuration = {
+            video: {}
+        };
+
+        configuration.video.width = inputConfig.width;
+        configuration.video.height = inputConfig.height;
+        configuration.video.framerate = parseFloat(inputConfig.framerate);
+        if (inputConfig.hdrMetadataType) {
+            configuration.video.hdrMetadataType = inputConfig.hdrMetadataType;
+        }
+        if (inputConfig.colorGamut) {
+            configuration.video.colorGamut = inputConfig.colorGamut;
+        }
+        if (inputConfig.transferFunction) {
+            configuration.video.transferFunction = inputConfig.transferFunction;
+        }
+
+        return configuration
+    }
+
+    function _getGenericMediaCapabilitiesAudioConfig(inputConfig) {
+        const configuration = {
+            audio: {}
+        };
+
+        if (inputConfig.samplerate) {
+            configuration.audio.samplerate = inputConfig.samplerate;
+        }
+
+        return configuration
+    }
+
+    function _enhanceGenericConfigurationWithKeySystemConfiguration(genericMediaCapabilitiesConfiguration, inputConfig) {
+        if (!inputConfig || !inputConfig.keySystemsMetadata || inputConfig.keySystemsMetadata.length === 0) {
+            return [genericMediaCapabilitiesConfiguration];
+        }
+
+        return inputConfig.keySystemsMetadata.map((keySystemMetadata) => {
+            const curr = { ...genericMediaCapabilitiesConfiguration };
+            if (keySystemMetadata.ks) {
+                curr.keySystemConfiguration = {};
+                if (keySystemMetadata.ks.systemString) {
+                    curr.keySystemConfiguration.keySystem = keySystemMetadata.ks.systemString;
+                }
+            }
+            return curr
+        })
     }
 
     /**

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -109,7 +109,7 @@ function CapabilitiesFilter() {
                             eventBus.trigger(Events.ADAPTATION_SET_REMOVED_NO_CAPABILITIES, {
                                 adaptationSet: as
                             });
-                            logger.warn(`AdaptationSet has been removed because of no supported Representation`);
+                            logger.info(`AdaptationSet has been removed because of no supported Representation`);
                         }
 
                         return supported;

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -115,6 +115,10 @@ function CapabilitiesFilter() {
                         return supported;
                     });
 
+                    if (period.AdaptationSet_asArray.length === 0) {
+                        logger.error(`All AdaptationSets have been removed from the period`);
+                    }
+
                     resolve();
                 })
                 .catch(() => {

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -211,14 +211,8 @@ function CapabilitiesFilter() {
     }
 
     function _addGenericAttributesToConfig(rep, config) {
-        // rep[DashConstants.CONTENT_PROTECTION] is an object, not an array.
-        // We check if it has any integer key to determine if there is any ContentProtection element
-        if (rep && rep[DashConstants.CONTENT_PROTECTION]) {
-            const value = rep[DashConstants.CONTENT_PROTECTION];
-            const hasProtection = Object.keys(value).some(key => Number.isInteger(+key));
-            if (hasProtection) {
-                config.keySystemsMetadata = protectionController.getSupportedKeySystemMetadataFromContentProtection(rep[DashConstants.CONTENT_PROTECTION])
-            }
+        if (rep && rep[DashConstants.CONTENT_PROTECTION+'_asArray'] && rep[DashConstants.CONTENT_PROTECTION+'_asArray'].length > 0) {
+            config.keySystemsMetadata = protectionController.getSupportedKeySystemMetadataFromContentProtection(rep[DashConstants.CONTENT_PROTECTION+'_asArray'])
         }
         return config
     }

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -3,6 +3,7 @@ import Debug from '../../core/Debug';
 import Constants from '../constants/Constants';
 import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
+import DashConstants from '../../dash/constants/DashConstants.js';
 
 function CapabilitiesFilter() {
 
@@ -14,6 +15,7 @@ function CapabilitiesFilter() {
         capabilities,
         settings,
         customParametersModel,
+        protectionController,
         logger;
 
 
@@ -36,6 +38,10 @@ function CapabilitiesFilter() {
 
         if (config.settings) {
             settings = config.settings;
+        }
+
+        if (config.protectionController) {
+            protectionController = config.protectionController;
         }
 
         if (config.customParametersModel) {
@@ -163,15 +169,19 @@ function CapabilitiesFilter() {
     }
 
     function _createConfiguration(type, rep, codec) {
+        let config = null;
         switch (type) {
             case Constants.VIDEO:
-                return _createVideoConfiguration(rep, codec);
+                config = _createVideoConfiguration(rep, codec);
+                break;
             case Constants.AUDIO:
-                return _createAudioConfiguration(rep, codec);
+                config = _createAudioConfiguration(rep, codec);
+                break;
             default:
-                return null;
-
+                return config;
         }
+
+        return _addGenericAttributesToConfig(rep, config);
     }
 
     function _createVideoConfiguration(rep, codec) {
@@ -198,6 +208,17 @@ function CapabilitiesFilter() {
             bitrate,
             samplerate
         };
+    }
+
+    function _addGenericAttributesToConfig(rep, config) {
+        if (rep && rep[DashConstants.CONTENT_PROTECTION]) {
+            const value = rep[DashConstants.CONTENT_PROTECTION];
+            const hasProtection = Object.keys(value).some(key => Number.isInteger(+key));
+            if (hasProtection) {
+                config.keySystemsMetadata = protectionController.getSupportedKeySystemMetadataFromContentProtection(rep[DashConstants.CONTENT_PROTECTION])
+            }
+        }
+        return config
     }
 
     function _filterUnsupportedEssentialProperties(manifest) {

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -211,6 +211,8 @@ function CapabilitiesFilter() {
     }
 
     function _addGenericAttributesToConfig(rep, config) {
+        // rep[DashConstants.CONTENT_PROTECTION] is an object, not an array.
+        // We check if it has any integer key to determine if there is any ContentProtection element
         if (rep && rep[DashConstants.CONTENT_PROTECTION]) {
             const value = rep[DashConstants.CONTENT_PROTECTION];
             const hasProtection = Object.keys(value).some(key => Number.isInteger(+key));


### PR DESCRIPTION
# Description

Origin PR: https://github.com/Dash-Industry-Forum/dash.js/pull/4548/

- Adds support for the keySystemConfiguration property of the Media Capabilities API. We use the keySystem string to filter AdaptationSets which are DRM protected but can't be decrypted on the underlying platform. For instance, this is required for HEVC tracks on Google Chrome as DRM is not supported then. 
- Enables useMediaCapabilitiesApi by default. We need to carefully test if this has any negative implications at this point.

## Tested
- [x] Live: Mixed-codec Sky, ESPN Sky, UFC linear
- [x] VOD: Hidive 

## Before

<img width="774" height="684" alt="before" src="https://github.com/user-attachments/assets/5a3f804e-9856-43c3-827e-aaa5b104f926" />

## After
<img width="661" height="587" alt="after" src="https://github.com/user-attachments/assets/70ad91c9-fcd1-4721-9fe7-a72f66126759" />

## Testing

[Sky UHD](https://www.skysportnow.co.nz/live/286302/sky-sports-uhd) (confirm it has both h265 and h264 variants)