### PR TITLE
fix: DORIS-3348 subtitles may not be displayed occasionally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.12",
+    "version": "4.7.13",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -132,13 +132,11 @@ function NotFragmentedTextBufferController(config) {
     }
 
     function setIsBufferingCompleted(value) {
-        if (isBufferingCompleted === value) {
+        if (!isInitFragmentLoaded || isBufferingCompleted === value) {
             return;
         }
 
-        if (isInitFragmentLoaded) {
-            isBufferingCompleted = value;
-        }
+        isBufferingCompleted = value;
 
         if (isBufferingCompleted) {
             triggerEvent(Events.BUFFERING_COMPLETED);

--- a/src/streaming/text/NotFragmentedTextBufferController.js
+++ b/src/streaming/text/NotFragmentedTextBufferController.js
@@ -54,12 +54,14 @@ function NotFragmentedTextBufferController(config) {
         initialized,
         mediaSource,
         sourceBufferSink,
-        initCache;
+        initCache,
+        isInitFragmentLoaded;
 
     function setup() {
         initialized = false;
         mediaSource = null;
         isBufferingCompleted = false;
+        isInitFragmentLoaded = false;
 
         initCache = InitCache(context).getInstance();
 
@@ -134,7 +136,9 @@ function NotFragmentedTextBufferController(config) {
             return;
         }
 
-        isBufferingCompleted = value;
+        if (isInitFragmentLoaded) {
+            isBufferingCompleted = value;
+        }
 
         if (isBufferingCompleted) {
             triggerEvent(Events.BUFFERING_COMPLETED);
@@ -143,6 +147,7 @@ function NotFragmentedTextBufferController(config) {
 
     function reset(errored) {
         eventBus.off(Events.INIT_FRAGMENT_LOADED, _onInitFragmentLoaded, instance);
+        isInitFragmentLoaded = false;
 
         if (!errored && sourceBufferSink) {
             sourceBufferSink.abort();
@@ -162,6 +167,8 @@ function NotFragmentedTextBufferController(config) {
         initCache.save(e.chunk);
 
         sourceBufferSink.append(e.chunk);
+
+        isInitFragmentLoaded = true;
 
         setIsBufferingCompleted(true);
     }


### PR DESCRIPTION
Subtitles may not be displayed if time and subtitle are specified at startup for dash handler.