### PR TITLE
Feat/doris 3523 initial track main role

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1089,6 +1089,7 @@ declare namespace dashjs {
                 audio?: TrackSwitchMode;
             }
             selectionModeForInitialTrack?: TrackSelectionMode
+            initialTrackSelectionPreferMainRole?: boolean
             fragmentRequestTimeout?: number;
             fragmentRequestProgressTimeout?: number;
             manifestRequestTimeout?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.12",
+    "version": "4.7.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.12",
+            "version": "4.7.14",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.13",
+    "version": "4.7.14",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -835,7 +835,7 @@ import Events from './events/Events';
  *
  *
  * @property {boolean} [initialTrackSelectionPreferMainRole=false]
- * When enabled, initial track selection filters to only tracks with role="main" before applying the selectionModeForInitialTrack logic. If no track has role="main", falls back to all tracks (default behavior).
+ * When enabled, initial track selection filters to only tracks with role="main" before applying either the selectionModeForInitialTrack logic or any customInitialTrackSelectionFunction. If no track has role="main", falls back to all tracks (default behavior).
  *
  * @property {number} [fragmentRequestTimeout=20000]
  * Time in milliseconds before timing out on loading a media fragment.

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -834,6 +834,9 @@ import Events from './events/Events';
  * This mode makes the player select the track with a widest range of bitrates.
  *
  *
+ * @property {boolean} [initialTrackSelectionPreferMainRole=false]
+ * When enabled, initial track selection filters to only tracks with role="main" before applying the selectionModeForInitialTrack logic. If no track has role="main", falls back to all tracks (default behavior).
+ *
  * @property {number} [fragmentRequestTimeout=20000]
  * Time in milliseconds before timing out on loading a media fragment.
  *
@@ -1017,6 +1020,7 @@ function Settings() {
                 video: Constants.TRACK_SWITCH_MODE_NEVER_REPLACE
             },
             selectionModeForInitialTrack: Constants.TRACK_SELECTION_MODE_HIGHEST_SELECTION_PRIORITY,
+            initialTrackSelectionPreferMainRole: false,
             fragmentRequestTimeout: 20000,
             fragmentRequestProgressTimeout: -1,
             manifestRequestTimeout: 10000,

--- a/src/streaming/controllers/MediaController.js
+++ b/src/streaming/controllers/MediaController.js
@@ -532,6 +532,13 @@ function MediaController() {
     function selectInitialTrack(type, tracks) {
         if (type === Constants.TEXT) return tracks[0];
 
+        if (settings.get().streaming.initialTrackSelectionPreferMainRole) {
+            const mainTracks = tracks.filter(t => t.roles && t.roles.includes('main'));
+            if (mainTracks.length > 0) {
+                tracks = mainTracks;
+            }
+        }
+
         let mode = settings.get().streaming.selectionModeForInitialTrack;
         let tmpArr;
         const customInitialTrackSelectionFunction = customParametersModel.getCustomInitialTrackSelectionFunction();

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -883,6 +883,70 @@ describe('MediaController', function () {
             });
         });
 
+        describe('"initialTrackSelectionPreferMainRole" setting', function () {
+            it('should select track with role "main" when enabled', function () {
+                settings.update({ streaming: { initialTrackSelectionPreferMainRole: true } });
+                const tracks = [
+                    {
+                        bitrateList: [{ bandwidth: 10000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['alternate']
+                    },
+                    {
+                        bitrateList: [{ bandwidth: 8000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['main']
+                    }
+                ];
+                const selection = mediaController.selectInitialTrack('video', tracks);
+                expect(selection.roles).to.include('main');
+            });
+
+            it('should fall back to all tracks when no track has role "main"', function () {
+                settings.update({ streaming: { initialTrackSelectionPreferMainRole: true } });
+                const tracks = [
+                    {
+                        bitrateList: [{ bandwidth: 10000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['alternate']
+                    },
+                    {
+                        bitrateList: [{ bandwidth: 8000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['supplementary']
+                    }
+                ];
+                const selection = mediaController.selectInitialTrack('video', tracks);
+                // highest bitrate wins since no "main" track exists
+                expect(selection.bitrateList[0].bandwidth).to.equal(10000);
+            });
+
+            it('should not filter by role when disabled', function () {
+                settings.update({ streaming: { initialTrackSelectionPreferMainRole: false } });
+                const tracks = [
+                    {
+                        bitrateList: [{ bandwidth: 10000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['alternate']
+                    },
+                    {
+                        bitrateList: [{ bandwidth: 8000 }],
+                        representationCount: 1,
+                        selectionPriority: 1,
+                        roles: ['main']
+                    }
+                ];
+                const selection = mediaController.selectInitialTrack('video', tracks);
+                // highest bitrate wins, ignoring roles
+                expect(selection.bitrateList[0].bandwidth).to.equal(10000);
+            });
+        });
+
         describe('custom initial track selection function', function () {
             beforeEach(function () {
 

--- a/test/unit/streaming.controllers.MediaController.js
+++ b/test/unit/streaming.controllers.MediaController.js
@@ -884,6 +884,14 @@ describe('MediaController', function () {
         });
 
         describe('"initialTrackSelectionPreferMainRole" setting', function () {
+            beforeEach(function () {
+                settings.update({
+                    streaming: {
+                        selectionModeForInitialTrack: Constants.TRACK_SELECTION_MODE_HIGHEST_BITRATE,
+                        initialTrackSelectionPreferMainRole: false
+                    }
+                });
+            });
             it('should select track with role "main" when enabled', function () {
                 settings.update({ streaming: { initialTrackSelectionPreferMainRole: true } });
                 const tracks = [


### PR DESCRIPTION
## Description of work
[View in Jira](https://dicetech.atlassian.net/browse/DORIS-3523)

## Short Summary
Add an opt-in setting `initialTrackSelectionPreferMainRole` that filters initial track selection to AdaptationSets with `Role="main"` before applying the existing selection mode logic. Falls back to default behaviour if no track has role main. 

Disabled by default.

```js
player.updateSettings({
    streaming: {
        initialTrackSelectionPreferMainRole: true
    }
});
```

## Screenshots

*Tested on LG via TVLabs*

**Before**

[Mux](https://dashboard.mux.com/organizations/qek18j/environments/6k8tns/views/a664974e-67f7-4362-9a9e-67ef3dd9a737?timeframe%5B%5D=60%3Aminutes&filters%5B%5D=viewer_user_id%3AATuhZT%7Cf0ef42ab-0aa8-4441-a776-4ad63f93499f)
<img width="1541" height="927" alt="image" src="https://github.com/user-attachments/assets/fbe1ddc3-5fe1-40e6-8dd7-b9665c60eb67" />

**After**

[Mux](https://dashboard.mux.com/organizations/qek18j/environments/6k8tns/views/9910cf43-bc10-47dc-9967-5b2a9001800c?filters%5B%5D=viewer_user_id%3AATuhZT%7Cf0ef42ab-0aa8-4441-a776-4ad63f93499f)
<img width="1541" height="880" alt="image" src="https://github.com/user-attachments/assets/31bc4205-bc1a-467e-967b-6ab07115004a" />
