### PR TITLE
Fix/doris 3464 filter mixed codec adaptation sets

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -975,7 +975,8 @@ declare namespace dashjs {
             capabilities?: {
                 filterUnsupportedEssentialProperties?: boolean,
                 useMediaCapabilitiesApi?: boolean,
-                replaceCodecs?: [string, string][]
+                replaceCodecs?: [string, string][],
+                filterMixedCodecAdaptationSets?: boolean
             },
             timeShiftBuffer?: {
                 calcFromSegmentTimeline?: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dashjs",
-    "version": "4.7.14",
+    "version": "4.7.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dashjs",
-            "version": "4.7.14",
+            "version": "4.7.15",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "bcp-47-match": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dashjs",
-    "version": "4.7.14",
+    "version": "4.7.15",
     "description": "A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers.",
     "author": "Dash Industry Forum",
     "license": "BSD-3-Clause",

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -600,6 +600,12 @@ import Events from './events/Events';
  * Enable to use the MediaCapabilities API to check whether codecs are supported. If disabled MSE.isTypeSupported will be used instead.
  * @property {Array.<[string, string]>} [replaceCodecs=[]]
  * List of codecs to be replaced.
+ * @property {boolean} [filterMixedCodecAdaptationSets=true]
+ * Enable to filter out representations whose codec family is incompatible with the first representation in
+ * the same AdaptationSet. This prevents ABR from switching to a representation with a different codec
+ * (e.g. switching between HEVC and AVC within the same AdaptationSet) that would be incompatible with
+ * the codec the MSE SourceBuffer was initialized with. Disable if you intentionally use changeType-based
+ * switching and have confirmed the platform supports it for the codec pairs in your stream.
  */
 
 /**
@@ -906,7 +912,8 @@ function Settings() {
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
                 useMediaCapabilitiesApi: true,
-                replaceCodecs: []
+                replaceCodecs: [],
+                filterMixedCodecAdaptationSets: true
             },
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,

--- a/src/streaming/utils/Capabilities.js
+++ b/src/streaming/utils/Capabilities.js
@@ -40,6 +40,14 @@ const codecCompatibilityTable = [
     {
         'codec': 'avc3',
         'compatibleCodecs': ['avc1']
+    },
+    {
+        'codec': 'hvc1',
+        'compatibleCodecs': ['hev1']
+    },
+    {
+        'codec': 'hev1',
+        'compatibleCodecs': ['hvc1']
     }
 ];
 

--- a/src/streaming/utils/CapabilitiesFilter.js
+++ b/src/streaming/utils/CapabilitiesFilter.js
@@ -164,7 +164,37 @@ function CapabilitiesFilter() {
                             }
                             return supported[i];
                         });
-                    resolve()
+
+                    // Filter out representations whose codec family is incompatible with the
+                    // first remaining representation. The SourceBuffer is initialized with the
+                    // codec of the first representation (index 0), so allowing ABR to switch to
+                    // a representation with a different codec family (e.g. HEVC vs AVC in the
+                    // same AdaptationSet) would cause the MSE SourceBuffer to reject the data.
+                    if (settings.get().streaming.capabilities.filterMixedCodecAdaptationSets &&
+                        as.Representation_asArray.length > 1) {
+                        const firstCodecRoot = as.Representation_asArray[0].codecs
+                            ? as.Representation_asArray[0].codecs.split('.')[0]
+                            : null;
+                        if (firstCodecRoot) {
+                            const beforeLength = as.Representation_asArray.length;
+                            as.Representation_asArray = as.Representation_asArray.filter((rep) => {
+                                if (!rep.codecs) {
+                                    return true;
+                                }
+                                const repCodecRoot = rep.codecs.split('.')[0];
+                                const compatible = capabilities.codecRootCompatibleWithCodec(firstCodecRoot, repCodecRoot);
+                                if (!compatible) {
+                                    logger.debug(`[Stream] Filtered out representation with codec ${rep.codecs} (codec family "${repCodecRoot}" is incompatible with primary codec family "${firstCodecRoot}")`);
+                                }
+                                return compatible;
+                            });
+                            if (as.Representation_asArray.length < beforeLength) {
+                                logger.info(`[Stream] Removed ${beforeLength - as.Representation_asArray.length} representations with mixed codec families to prevent SourceBuffer codec mismatch`);
+                            }
+                        }
+                    }
+
+                    resolve();
                 })
                 .catch(() => {
                     resolve();


### PR DESCRIPTION
## Description

Added `streaming.capabilities.filterMixedCodecAdaptationSets` to filter mixed AVC and HEVC renditions in the same adaptation set.